### PR TITLE
Support ruby 3.2

### DIFF
--- a/lib/weasyprint/weasyprint.rb
+++ b/lib/weasyprint/weasyprint.rb
@@ -27,7 +27,7 @@ class WeasyPrint
     @options = WeasyPrint.configuration.default_options.merge(options)
     @options = normalize_options(@options)
 
-    raise NoExecutableError.new unless File.exists?(WeasyPrint.configuration.weasyprint)
+    raise NoExecutableError.new unless File.exist?(WeasyPrint.configuration.weasyprint)
   end
 
   def command(path = nil)


### PR DESCRIPTION
Use `File.exist?` instead of `File.exists?` as it isn't supported.

See https://ruby-doc.org/3.2.0/File.html#method-c-exist-3F